### PR TITLE
Dockerize all the servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:0.10
+
+ADD package.json /code/
+WORKDIR /code
+RUN npm install
+ADD . /code
+
+CMD ["./node_modules/strongloop/bin/slc", "run"]

--- a/README.md
+++ b/README.md
@@ -32,4 +32,8 @@ An alternative way to run the simple-rest-server is via [Docker](https://www.doc
   fig up
   ```
   
-6. Navigate to [localhost:1337/explorer](http://localhost:1337/explorer) (or [http://192.168.59.103:1337/explorer/](http://192.168.59.103:1337/explorer/) if using boot2docker) to view your api. Congratulations! You can now play around with it using the explorer or head over to [Simple REST Website](https://github.com/simpulton/simple-rest-website) for a super-simple front-end application that connects to your new API!
+Navigate to [localhost:1337/explorer](http://localhost:1337/explorer) (or [http://192.168.59.103:1337/explorer/](http://192.168.59.103:1337/explorer/) if using boot2docker) to view your api. 
+
+Congratulations! 
+
+You can now play around with it using the explorer or head over to [Simple REST Website](https://github.com/simpulton/simple-rest-website) for a super-simple front-end application that connects to your new API!

--- a/README.md
+++ b/README.md
@@ -22,5 +22,14 @@ You will need:
   slc run
   ```
   * Note: If you want to use the version without authentication, checkout the "without-auth" branch and restart the API if necessary. Be sure to do the same in the simple-rest-website repo.
+
+### Alternative - Docker
+An alternative way to run the simple-rest-server is via [Docker](https://www.docker.com/) and [fig](http://www.fig.sh/).
+
+  ```bash
+  git clone git@github.com:simpulton/simple-rest-api.git
+  cd simple-rest-api
+  fig up
+  ```
   
-6. Navigate to [localhost:1337/explorer](http://localhost:1337/explorer) to view your api. Congratulations! You can now play around with it using the explorer or head over to [Simple REST Website](https://github.com/simpulton/simple-rest-website) for a super-simple front-end application that connects to your new API!
+6. Navigate to [localhost:1337/explorer](http://localhost:1337/explorer) (or [http://192.168.59.103:1337/explorer/](http://192.168.59.103:1337/explorer/) if using boot2docker) to view your api. Congratulations! You can now play around with it using the explorer or head over to [Simple REST Website](https://github.com/simpulton/simple-rest-website) for a super-simple front-end application that connects to your new API!

--- a/fig.yml
+++ b/fig.yml
@@ -4,6 +4,8 @@ web:
     - "1337:1337"
   links:
     - mongo
+  environment:
+    NODE_ENV: fig
 
 mongo:
   image: mongo:2.6

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,11 @@
+web:
+  build: .
+  ports:
+    - "1337:1337"
+  links:
+    - mongo
+
+mongo:
+  image: mongo:2.6
+  ports:
+    - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",
+    "strongloop": "^2.10.3",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.0.0",
     "loopback-connector-mongodb": "^1.4.4",

--- a/server/datasources.fig.json
+++ b/server/datasources.fig.json
@@ -1,10 +1,6 @@
 {
-  "db": {
-    "name": "db",
-    "connector": "memory"
-  },
   "mongoDB": {
-    "host": "localhost",
+    "host": "mongo",
     "port": 27017,
     "database": "strongloop",
     "name": "mongoDB",

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -4,6 +4,7 @@
     "connector": "memory"
   },
   "mongoDB": {
+    "host": "mongo",
     "port": 27017,
     "database": "strongloop",
     "name": "mongoDB",


### PR DESCRIPTION
Enable users to run the simple-rest-api environment via Docker
- Create a Dockerfile to install and run the simple rest api server (strongloop)
- Create a fig.yml to manage the simple rest api server and mongodb as a cohesive environment
- Document how to run the environment via fig
