### PR TITLE
Configure simple-rest-api via env vars and deploy to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: slc run

--- a/fig.yml
+++ b/fig.yml
@@ -5,7 +5,7 @@ web:
   links:
     - mongo
   environment:
-    NODE_ENV: fig
+    MONGO_URL: "mongodb://mongo:27017"
 
 mongo:
   image: mongo:2.6

--- a/server/config.local.js
+++ b/server/config.local.js
@@ -1,0 +1,11 @@
+var port = process.env.PORT ||
+	1337;
+var url = "http://localhost:" + port;
+
+console.log("Using port: " + port);
+console.log("Using url: " + url);
+
+module.exports = {
+  port: port,
+  url: url
+};

--- a/server/datasources.fig.json
+++ b/server/datasources.fig.json
@@ -1,9 +1,7 @@
 {
   "mongoDB": {
-    "host": "mongo",
-    "port": 27017,
+    "connector": "mongodb",
     "database": "strongloop",
-    "name": "mongoDB",
-    "connector": "mongodb"
+    "name": "mongoDB"
   }
 }

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -4,10 +4,8 @@
     "connector": "memory"
   },
   "mongoDB": {
-    "host": "localhost",
-    "port": 27017,
+    "connector": "mongodb",
     "database": "strongloop",
-    "name": "mongoDB",
-    "connector": "mongodb"
+    "name": "mongoDB"
   }
 }

--- a/server/datasources.local.js
+++ b/server/datasources.local.js
@@ -1,0 +1,15 @@
+// http://stackoverflow.com/questions/21651567/how-to-configure-strongloop-loopback-mongodb-datasource-for-deployment-to-heroku
+var mongoUri = process.env.MONGOLAB_URI ||
+  process.env.MONGOHQ_URL || 
+  process.env.MONGO_URL ||
+  'mongodb://localhost/strongloop';
+
+console.log("Using mongoUri: " + mongoUri);
+
+module.exports = {
+  mongoDB: {
+    defaultForType: "mongodb",
+    connector: "loopback-connector-mongodb",
+    url: mongoUri
+  }
+};


### PR DESCRIPTION
Change configuration of the simple-rest-api so that its server listening port and mongo connection information are managed via environment variables:
- PORT: default 1337
- MONGO_URI: mongodb://localhost/strongloop

Add Procfile for deployment to Heroku.

Cleanup heroku and mongo configs.
